### PR TITLE
fix scroll error & fix fairy container size

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -34,6 +34,12 @@ const style = theme => ({
     minWidth: 0,
     overflow: 'auto',
   },
+  container: {
+    width: '100%',
+    minHeight: 'calc(100% - 64px)',
+    position: 'absolute',
+    top: '64px',
+  },
   mixin: theme.mixins.toolbar,
 });
 
@@ -71,7 +77,7 @@ class App extends React.Component {
         <Menu />
         <main id="content" className={classes.content}>
           <div className={classes.mixin} />
-          <div style={{ width: '100%', height: 'calc(100% - 64px)' }}>
+          <div className={classes.container}>
             <Route exact path="/" component={Home} />
             <Route exact path="/doll" component={DollDict} />
             <Route path="/doll/:id" component={DollDetail} />

--- a/src/components/fairy/FairyDict.jsx
+++ b/src/components/fairy/FairyDict.jsx
@@ -11,7 +11,6 @@ import FairyCard from './components/FairyCard';
 const style = {
   wrapper: {
     width: '100%',
-    margin: '0 10px',
   },
 };
 // {list.map(fairy => <FairyCard key={fairy.id} {...fairy} />)}

--- a/src/components/home/style.css
+++ b/src/components/home/style.css
@@ -1,5 +1,18 @@
-body {
-  overflow: hidden;
+body{
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: scroll;
+  overflow-scrolling: touch;
+  -webkit-overflow-scrolling: touch;
+}
+
+#content{
+  max-width: 100%;
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 .body-content{


### PR DESCRIPTION
수정점
1. 모바일에서 모든화면에 스크롤이 부드럽지않은 문제를 고쳤습니다
2. ios에서 status bar를 눌러서 scrolling top으로 가는 기능이 동작하지 않는 문제를 고쳤습니다
3. fairydict페이지에서 가로스크롤이 발생한 문제를 고쳤습니다 

알려진 문제점 
1. ios에서 home페이지에서 스크롤을 할시 이미지가 튀는 현상이 발생합니다 

수정한 곳에서 문제가 있을 수 있는 곳 
1. webkit이 아닌 브라우져에서 1번 수정점이 제대로 동작하지않을 수 있습니다. 
