### PR TITLE
스크롤 관련 문제 수정 & 공수요정 스킬 표시 오류 수정

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -36,9 +36,7 @@ const style = theme => ({
   },
   container: {
     width: '100%',
-    minHeight: 'calc(100% - 64px)',
-    position: 'absolute',
-    top: '64px',
+    height: 'calc(100% - 64px)',
   },
   mixin: theme.mixins.toolbar,
 });

--- a/src/components/fairydetail/components/SkillBox.jsx
+++ b/src/components/fairydetail/components/SkillBox.jsx
@@ -32,12 +32,22 @@ class SkillBox extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const description = this.getDesc(
+    let description = this.getDesc(
       this.props.skill.desc,
       this.props.skill.dataPool,
       this.state.lv,
     );
-
+    if (this.props.skill.id === 1011) {
+      if (this.props.skill.dataPool.MV[9] === 0) {
+        const temp = this.props.skill.dataPool;
+        temp.MV[9] = '무한대';
+        description = this.getDesc(
+          this.props.skill.desc,
+          temp,
+          this.state.lv,
+        );
+      }
+    }
     let cd = this.props.skill.dataPool.CD;
     if (cd === undefined) {
       cd = '없음';

--- a/src/components/fairydetail/components/style.js
+++ b/src/components/fairydetail/components/style.js
@@ -3,7 +3,6 @@ const style = theme => ({
   root: {
     width: '100%',
     height: '100%',
-    overflowX: 'hidden',
   },
   titleWrapper: {
     zIndex: '200',

--- a/src/components/home/style.css
+++ b/src/components/home/style.css
@@ -4,21 +4,17 @@ body{
   left: 0;
   right: 0;
   bottom: 0;
-  overflow: scroll;
-  overflow-scrolling: touch;
-  -webkit-overflow-scrolling: touch;
 }
 
 #content{
-  max-width: 100%;
-  overflow: scroll;
   -webkit-overflow-scrolling: touch;
+  overflow-scrolling: touch;
 }
 
 .body-content{
   display: grid;
   grid-template-columns: repeat(12,1fr);
-  grid-auto-rows: calc(100vh/12);
+  grid-auto-rows: calc((100vh - 80px) / 12);
   position: relative;
   top: 0;
   left: 0;
@@ -286,6 +282,11 @@ and (orientation: portrait) {
 @media only screen
 and (max-device-width: 480px) {
   body { overflow: visible; }
+
+  .withRouter-Connect-App---container-3{
+    position: absolute;
+    top: 64px;
+  }
 
   .body-content{
     grid-template-columns: 1fr;


### PR DESCRIPTION
수정점
1. 모바일에서 모든화면에 스크롤이 부드럽지않은 문제를 고쳤습니다
2. ios에서 status bar를 눌러서 scrolling top으로 가는 기능이 동작하지 않는 문제를 고쳤습니다
3. fairydict페이지에서 가로스크롤이 발생한 문제를 고쳤습니다 
4. 공수요정의 스킬 표시 오류를 수정하였습니다

문제를 일으킬 수 있는 부분 :
2를 구현하기 위해 최종페이지에나오는 클래스이름을 그대로 가져다 쓴부분이있습니다
src/components/home/style.css 286:3 에서
.withRouter-Connect-App---container-3 
부분입니다 