### PR TITLE
fix doll dict layout

### DIFF
--- a/src/components/doll/DollDict.jsx
+++ b/src/components/doll/DollDict.jsx
@@ -19,6 +19,37 @@ const style = theme => ({
       minWidth: 660,
     },
   },
+  cardWrapper: {
+    width: '1520px',
+    margin: '0 auto',
+    [theme.breakpoints.down(1857)]: {
+      width: '1330px',
+    },
+    [theme.breakpoints.down(1667)]: {
+      width: '1140px',
+    },
+    [theme.breakpoints.down(1560)]: {
+      width: '1330px',
+    },
+    [theme.breakpoints.down(1370)]: {
+      width: '1140px',
+    },
+    [theme.breakpoints.down(1180)]: {
+      width: '950px',
+    },
+    [theme.breakpoints.down(990)]: {
+      width: '760px',
+    },
+    [theme.breakpoints.down(800)]: {
+      width: '570px',
+    },
+    [theme.breakpoints.down(610)]: {
+      width: '380px',
+    },
+    [theme.breakpoints.down(480)]: {
+      width: '320px',
+    },
+  },
 });
 
 class DollDict extends React.Component {
@@ -30,7 +61,7 @@ class DollDict extends React.Component {
         <Grid item xs={12}>
           <SearchBar />
         </Grid>
-        <Grid item xs={12}>
+        <Grid className={classes.cardWrapper}>
           {list.map(doll => <DollCard key={doll.id} {...doll} />)}
         </Grid>
       </Grid>

--- a/src/components/doll/components/style.js
+++ b/src/components/doll/components/style.js
@@ -1,6 +1,6 @@
 import cardbg from './resources/cardbg.png';
 
-const style = {
+const style = theme => ({
   root: {
     display: 'inline-block',
     position: 'relative',
@@ -10,6 +10,12 @@ const style = {
     textDecoration: 'none',
     backgroundImage: `url(${cardbg})`,
     backgroundSize: '100%',
+    [theme.breakpoints.down(480)]: {
+      width: 150,
+      height: 300,
+      margin: '10px 5px',
+      backgroundSize: '170px 300px',
+    },
   },
   typeIcon: {
     position: 'absolute',
@@ -32,6 +38,12 @@ const style = {
     zIndex: 1000,
     '&:hover': {
       backgroundPosition: '-100% 0',
+    },
+    [theme.breakpoints.down(480)]: {
+      backgroundSize: 300,
+      '&:hover': {
+        backgroundPosition: '-100% 0',
+      },
     },
   },
   caption: {
@@ -56,6 +68,11 @@ const style = {
     fontSize: 19,
     fontWeight: 400,
     color: '#ababab',
+    [theme.breakpoints.down(480)]: {
+      fontSize: 12,
+      left: 129,
+      lineHeight: '25px',
+    },
   },
 
   general: { background: 'linear-gradient(135deg, #a2a2a2, #a2a2a2 85%, transparent 85%)' },
@@ -71,6 +88,6 @@ const style = {
     fontSize: 20,
     color: '#FFB600',
   },
-};
+});
 
 export default style;


### PR DESCRIPTION
수정점: dolldict 페이지의 레이아웃을 고쳤습니다 이제 가운데 정렬이 잘되고 모바일화면에서 카드가 한줄에 2개씩보입니다

fairydict와 마찬가지로 데스크탑은 가로 1920px 이하 화면에서 
모바일은 320px 이상 화면에서 지원합니다
